### PR TITLE
Fix nl.dionsegijn.konfetti failing to resolve by updating it from 1.1.2 to 1.3.2

### DIFF
--- a/Assets/Cafebazaar/Core/Script/Editor/CafeBazaarPlugin_Dependencies.xml
+++ b/Assets/Cafebazaar/Core/Script/Editor/CafeBazaarPlugin_Dependencies.xml
@@ -11,6 +11,6 @@
     <androidPackage spec="androidx.cardview:cardview:1.0.0"/>
     <androidPackage spec="androidx.constraintlayout:constraintlayout:1.1.2"/>
     <androidPackage spec="org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.41"/>
-    <androidPackage spec="nl.dionsegijn:konfetti:1.1.2"/>
+    <androidPackage spec="nl.dionsegijn:konfetti:1.3.2"/>
   </androidPackages>
 </dependencies>


### PR DESCRIPTION
nl.dionsegijn.konfetti version 1.1.2 is no longer available and fails to resolve, the current legacy version is 1.3.2, I would recommend you to update the project to use the latest v2, but for now, this fix is enough.

More info: https://github.com/DanielMartinus/Konfetti